### PR TITLE
Add more system info from payload

### DIFF
--- a/lavaplayer/objects.py
+++ b/lavaplayer/objects.py
@@ -10,9 +10,14 @@ class Info:
     Info websocket for connection
     """
     playing_players: int
+    memory_reservable: int
     memory_used: int
     memory_free: int
+    memory_allocated: int
     players: int
+    cpu_cores: int
+    system_load: float
+    lavalink_load: float
     uptime: int
 
 

--- a/lavaplayer/websocket.py
+++ b/lavaplayer/websocket.py
@@ -102,10 +102,15 @@ class WS:
         if payload["op"] == "stats":
             self.client.info = Info(
                 playing_players=payload["playingPlayers"],
+                memory_reservable=payload["memory"]["reservable"],
                 memory_used=payload["memory"]["used"],
                 memory_free=payload["memory"]["free"],
+                memory_allocated=payload["memory"]["allocated"],
                 players=payload["players"],
-                uptime=payload["uptime"]
+                cpu_cores=payload["cpu"]["cores"],
+                system_load=payload["cpu"]["systemLoad"],
+                lavalink_load=payload["cpu"]["lavalinkLoad"],
+                uptime=payload["uptime"],
             )
 
         elif payload["op"] == "playerUpdate":


### PR DESCRIPTION
I think it would be a great idea adding more system information about resources being used by lavalink server. The current payload send us many stats. However, in the previous class Info there was only some of them.
The new stats are:
- memory_reservable `int`
- memory_allocated `int`
- cpu_cores `int`
- system_load `float`
- lavalink_load `float`
